### PR TITLE
Adding support for specifying number of occupied orbitals to extract

### DIFF
--- a/src/python/qepsi4/_psi4.py
+++ b/src/python/qepsi4/_psi4.py
@@ -3,7 +3,6 @@ import numpy as np
 from openfermion import InteractionOperator, general_basis_change, MolecularData
 from openfermion.config import EQ_TOLERANCE
 
-
 def run_psi4(
     geometry,
     basis="STO-3G",
@@ -83,7 +82,13 @@ def run_psi4(
         if n_active_extract is not None:
             orbitals = wavefunction.Ca().to_array(dense=True)
             n_orbitals = n_active_extract
-            if freeze_core_extract:
+            if n_occupied_extract is not None:
+                if wavefunction.nalpha() != wavefunction.nbeta():
+                    raise ValueError(f'Requesting a number of occupied molecular orbitals not supported when number of alpha and beta electrons is unequal.')
+                if n_occupied_extract > wavefunction.nalpha():
+                    raise ValueError(f'Number of occupied molecular orbitals to extract ({n_occupied_extract}) is larger than number of occupied molecular orbitals ({wavefunction.nalpha()}).')
+                n_orbitals += wavefunction.nalpha() - n_occupied_extract
+            elif freeze_core_extract:
                 n_orbitals += wavefunction.nfrzc()
             orbitals = orbitals[:, :n_orbitals]
             orbitals = psi4.core.Matrix.from_array(orbitals)

--- a/src/python/qepsi4/_psi4.py
+++ b/src/python/qepsi4/_psi4.py
@@ -90,12 +90,14 @@ def run_psi4(
         hamiltonian = get_ham_from_psi4(
             wavefunction,
             mints,
-            n_active_extract,
-            freeze_core_extract,
-            orbitals,
-            molecule.nuclear_repulsion_energy(),
+            n_active_extract=n_active_extract,
+            n_occupied_extract=n_occupied_extract,
+            freeze_core_extract=freeze_core_extract,
+            orbs=orbitals,
+            nuclear_repulsion_energy=molecule.nuclear_repulsion_energy(),
         )
-
+    
+    psi4.core.clean()
     return results, hamiltonian
 
 
@@ -153,9 +155,9 @@ def get_ham_from_psi4(
     # Build the transformation matrices, i.e. the orbitals for which
     # we want the integrals, as Psi4.core.Matrix objects
     n_core_extract = 0
-    if freeze_core_extract and not n_occupied_extract:
+    if freeze_core_extract and not n_occupied_extract is None:
         n_core_extract = wfn.nfrzc()
-    else:
+    elif n_occupied_extract is not None:
         if wfn.nalpha() != wfn.nbeta():
             raise ValueError(f'Requesting a number of occupied molecular orbitals not supported when number of alpha and beta electrons is unequal.')
         if n_occupied_extract > wfn.nalpha():

--- a/src/python/qepsi4/_psi4.py
+++ b/src/python/qepsi4/_psi4.py
@@ -3,11 +3,21 @@ import numpy as np
 from openfermion import InteractionOperator, general_basis_change, MolecularData
 from openfermion.config import EQ_TOLERANCE
 
-def run_psi4(geometry, basis='STO-3G', multiplicity=1, charge=0,
-        method='scf', reference='rhf',
-        freeze_core=False, n_active=None,
-        save_hamiltonian=False, options=None,
-        n_active_extract=None, freeze_core_extract=False):
+
+def run_psi4(
+    geometry,
+    basis="STO-3G",
+    multiplicity=1,
+    charge=0,
+    method="scf",
+    reference="rhf",
+    freeze_core=False,
+    n_active=None,
+    save_hamiltonian=False,
+    options=None,
+    n_active_extract=None,
+    freeze_core_extract=False,
+):
     """Generate an input file in the Psi4 python domain-specific language for
     a molecule.
     
@@ -34,29 +44,28 @@ def run_psi4(geometry, basis='STO-3G', multiplicity=1, charge=0,
             (openfermion.InteractionOperator).
     """
 
-    geometry_str = f'{charge} {multiplicity}\n'
-    for atom in geometry['sites']:
-        geometry_str += '{} {} {} {}\n'.format(atom['species'],
-                                               atom['x'],
-                                               atom['y'],
-                                               atom['z'])
+    geometry_str = f"{charge} {multiplicity}\n"
+    for atom in geometry["sites"]:
+        geometry_str += "{} {} {} {}\n".format(
+            atom["species"], atom["x"], atom["y"], atom["z"]
+        )
 
-    geometry_str += '\nunits angstrom\n'
+    geometry_str += "\nunits angstrom\n"
     c1_sym = save_hamiltonian or n_active
     if c1_sym:
-        geometry_str += 'symmetry c1\n'
-    
+        geometry_str += "symmetry c1\n"
+
     molecule = psi4.geometry(geometry_str)
-    psi4.set_options({'reference': reference, 'basis': basis})
+    psi4.set_options({"reference": reference, "basis": basis})
     energy, wavefunction = psi4.energy(method, return_wfn=True)
 
     results = {
-        'energy': energy,
-        'n_alpha': wavefunction.nalpha(),
-        'n_beta': wavefunction.nbeta(),
-        'n_mo': wavefunction.nmo(),
-        'n_frozen_core': wavefunction.nfrzc(),
-        'n_frozen_valence': wavefunction.frzvpi().sum()
+        "energy": energy,
+        "n_alpha": wavefunction.nalpha(),
+        "n_beta": wavefunction.nbeta(),
+        "n_mo": wavefunction.nmo(),
+        "n_frozen_core": wavefunction.nfrzc(),
+        "n_frozen_valence": wavefunction.frzvpi().sum(),
     }
 
     hamiltonian = None
@@ -70,17 +79,26 @@ def run_psi4(geometry, basis='STO-3G', multiplicity=1, charge=0,
                 n_orbitals += wavefunction.nfrzc()
             orbitals = orbitals[:, :n_orbitals]
             orbitals = psi4.core.Matrix.from_array(orbitals)
-        hamiltonian = get_ham_from_psi4(wavefunction,
-                                        mints,
-                                        n_active_extract,
-                                        freeze_core_extract,
-                                        orbitals,
-                                        molecule.nuclear_repulsion_energy())
+        hamiltonian = get_ham_from_psi4(
+            wavefunction,
+            mints,
+            n_active_extract,
+            freeze_core_extract,
+            orbitals,
+            molecule.nuclear_repulsion_energy(),
+        )
 
     return results, hamiltonian
 
-def get_ham_from_psi4(wfn, mints, n_active_extract=None, freeze_core_extract=False, 
-                      orbs=None, nuclear_repulsion_energy=0):
+
+def get_ham_from_psi4(
+    wfn,
+    mints,
+    n_active_extract=None,
+    freeze_core_extract=False,
+    orbs=None,
+    nuclear_repulsion_energy=0,
+):
     """Get a molecular Hamiltonian from a Psi4 calculation.
 
     Args:
@@ -101,8 +119,10 @@ def get_ham_from_psi4(wfn, mints, n_active_extract=None, freeze_core_extract=Fal
             included.
     """
 
-    assert wfn.same_a_b_orbs(), "Extraction of Hamiltonian from wavefunction" + \
-        "with different alpha and beta orbitals not yet supported :("
+    assert wfn.same_a_b_orbs(), (
+        "Extraction of Hamiltonian from wavefunction"
+        + "with different alpha and beta orbitals not yet supported :("
+    )
 
     # Note: code refactored to use Psi4 integral-transformation routines
     # no more storing the whole two-electron integral tensor when only an
@@ -110,9 +130,11 @@ def get_ham_from_psi4(wfn, mints, n_active_extract=None, freeze_core_extract=Fal
 
     orbitals = wfn.Ca().to_array(dense=True)
     one_body_integrals = general_basis_change(
-        np.asarray(mints.ao_kinetic()), orbitals, (1, 0))
+        np.asarray(mints.ao_kinetic()), orbitals, (1, 0)
+    )
     one_body_integrals += general_basis_change(
-        np.asarray(mints.ao_potential()), orbitals, (1, 0))
+        np.asarray(mints.ao_potential()), orbitals, (1, 0)
+    )
 
     # Build the transformation matrices, i.e. the orbitals for which
     # we want the integrals, as Psi4.core.Matrix objects
@@ -123,29 +145,30 @@ def get_ham_from_psi4(wfn, mints, n_active_extract=None, freeze_core_extract=Fal
         trf_mat = wfn.Ca()
         n_active_extract = wfn.nmo() - n_core_extract
     else:
-    # If orbs is given, it allows us to perform the two-electron integrals
-    # transformation only in the space of active orbitals. Otherwise, we
-    # transform all orbitals and filter them out in the get_ham_from_integrals
-    # function
+        # If orbs is given, it allows us to perform the two-electron integrals
+        # transformation only in the space of active orbitals. Otherwise, we
+        # transform all orbitals and filter them out in the get_ham_from_integrals
+        # function
         if orbs is None:
             trf_mat = wfn.Ca()
         else:
-            assert(orbs.to_array(dense=True).shape[1] == n_active_extract + n_core_extract)
+            assert (
+                orbs.to_array(dense=True).shape[1] == n_active_extract + n_core_extract
+            )
             trf_mat = orbs
 
     two_body_integrals = np.asarray(mints.mo_eri(trf_mat, trf_mat, trf_mat, trf_mat))
     n_orbitals = trf_mat.shape[1]
-    two_body_integrals.reshape((n_orbitals, n_orbitals,
-                                n_orbitals, n_orbitals))
-    two_body_integrals = np.einsum('psqr', two_body_integrals)
+    two_body_integrals.reshape((n_orbitals, n_orbitals, n_orbitals, n_orbitals))
+    two_body_integrals = np.einsum("psqr", two_body_integrals)
 
     # Truncate
-    one_body_integrals[np.absolute(one_body_integrals) < EQ_TOLERANCE] = 0.
-    two_body_integrals[np.absolute(two_body_integrals) < EQ_TOLERANCE] = 0.
+    one_body_integrals[np.absolute(one_body_integrals) < EQ_TOLERANCE] = 0.0
+    two_body_integrals[np.absolute(two_body_integrals) < EQ_TOLERANCE] = 0.0
 
     if n_active_extract is None and not freeze_core_extract:
         occupied_indices = None
-        active_indices = None    
+        active_indices = None
     else:
         # Indices of occupied molecular orbitals
         occupied_indices = range(n_core_extract)
@@ -154,14 +177,15 @@ def get_ham_from_psi4(wfn, mints, n_active_extract=None, freeze_core_extract=Fal
         active_indices = range(n_core_extract, n_core_extract + n_active_extract)
 
     # In order to keep the MolecularData class happy, we need a 'valid' molecule
-    molecular_data = MolecularData(geometry=[('H', (0, 0, 0))],
-                                   basis='',
-                                   multiplicity=2)
+    molecular_data = MolecularData(
+        geometry=[("H", (0, 0, 0))], basis="", multiplicity=2
+    )
 
     molecular_data.one_body_integrals = one_body_integrals
     molecular_data.two_body_integrals = two_body_integrals
     molecular_data.nuclear_repulsion = nuclear_repulsion_energy
-    hamiltonian = molecular_data.get_molecular_hamiltonian(occupied_indices,
-                                            active_indices)
+    hamiltonian = molecular_data.get_molecular_hamiltonian(
+        occupied_indices, active_indices
+    )
 
-    return(hamiltonian)
+    return hamiltonian

--- a/src/python/qepsi4/_psi4_test.py
+++ b/src/python/qepsi4/_psi4_test.py
@@ -7,17 +7,24 @@ from openfermion import (
 import numpy as np
 import math
 
+hydrogen_geometry = {
+    "sites": [
+        {"species": "H", "x": 0, "y": 0, "z": 0},
+        {"species": "H", "x": 0, "y": 0, "z": 1.7},
+    ]
+}
 
-def test_run_psi4(self):
+dilithium_geometry = {
+    "sites": [
+        {"species": "Li", "x": 0, "y": 0, "z": 0},
+        {"species": "Li", "x": 0, "y": 0, "z": 2.67},
+    ]
+}
 
-    geometry = {
-        "sites": [
-            {"species": "H", "x": 0, "y": 0, "z": 0},
-            {"species": "H", "x": 0, "y": 0, "z": 1.7},
-        ]
-    }
 
-    results, hamiltonian = run_psi4(geometry, save_hamiltonian=True)
+def test_run_psi4():
+
+    results, hamiltonian = run_psi4(hydrogen_geometry, save_hamiltonian=True)
     assert math.isclose(results["energy"], -0.8544322638069642)
     assert results["n_alpha"] == 1
     assert results["n_beta"] == 1
@@ -29,7 +36,50 @@ def test_run_psi4(self):
     qubit_operator = qubit_operator_sparse(jordan_wigner(hamiltonian))
     energy, state = jw_get_ground_state_at_particle_number(qubit_operator, 2)
 
-    results_cisd, hamiltonian = run_psi4(geometry, method="ccsd")
+    results_cisd, hamiltonian = run_psi4(hydrogen_geometry, method="ccsd")
 
     # For this system, the CCSD energy should be exact.
     assert math.isclose(energy, results_cisd["energy"])
+
+
+def test_run_psi4_using_n_occupied_extract():
+    results, hamiltonian = run_psi4(
+        hydrogen_geometry,
+        method="scf",
+        basis="6-31G",
+        n_active_extract=2,
+        n_occupied_extract=1,
+        save_hamiltonian=True
+    )
+
+    assert hamiltonian.n_qubits == 4
+
+def test_run_psi4_n_occupied_extract_inconsistent_with_n_active_extract():
+    try:
+        run_psi4(
+            dilithium_geometry,
+            method="scf",
+            basis="STO-3G",
+            n_active_extract=2,
+            n_occupied_extract=3,
+        save_hamiltonian=True
+        )
+    except ValueError:
+        pass
+    else:
+        assert False
+
+def test_run_psi4_n_occupied_extract_inconsistent_with_num_electrons():
+    try:
+        run_psi4(
+            dilithium_geometry,
+            method="scf",
+            basis="STO-3G",
+            n_active_extract=4,
+            n_occupied_extract=2,
+        save_hamiltonian=True
+        )
+    except ValueError:
+        pass
+    else:
+        assert False

--- a/src/python/qepsi4/_psi4_test.py
+++ b/src/python/qepsi4/_psi4_test.py
@@ -54,6 +54,10 @@ def test_run_psi4_using_n_occupied_extract():
 
     assert hamiltonian.n_qubits == 8
 
+    qubit_operator = qubit_operator_sparse(jordan_wigner(hamiltonian))
+    energy, state = jw_get_ground_state_at_particle_number(qubit_operator, 4)
+    assert math.isclose(energy, -14.654620243980217)
+
 def test_run_psi4_n_occupied_extract_inconsistent_with_n_active_extract():
     try:
         run_psi4(

--- a/src/python/qepsi4/_psi4_test.py
+++ b/src/python/qepsi4/_psi4_test.py
@@ -105,4 +105,5 @@ def test_run_psi4_freeze_core_extract():
         save_hamiltonian=True,
     )
 
+    # With STO-3G, each Li atom has one 1s orbital, one 2s orbital, and three 2p orbitals. The 1s orbitals are considered core orbitals.
     assert hamiltonian.n_qubits == 2 * 2 * (1 + 3)

--- a/src/python/qepsi4/_psi4_test.py
+++ b/src/python/qepsi4/_psi4_test.py
@@ -44,15 +44,15 @@ def test_run_psi4():
 
 def test_run_psi4_using_n_occupied_extract():
     results, hamiltonian = run_psi4(
-        hydrogen_geometry,
+        dilithium_geometry,
         method="scf",
-        basis="6-31G",
-        n_active_extract=2,
-        n_occupied_extract=1,
+        basis="STO-3G",
+        n_active_extract=4,
+        n_occupied_extract=2,
         save_hamiltonian=True
     )
 
-    assert hamiltonian.n_qubits == 4
+    assert hamiltonian.n_qubits == 8
 
 def test_run_psi4_n_occupied_extract_inconsistent_with_n_active_extract():
     try:
@@ -72,9 +72,9 @@ def test_run_psi4_n_occupied_extract_inconsistent_with_n_active_extract():
 def test_run_psi4_n_occupied_extract_inconsistent_with_num_electrons():
     try:
         run_psi4(
-            dilithium_geometry,
+            hydrogen_geometry,
             method="scf",
-            basis="STO-3G",
+            basis="6-31G",
             n_active_extract=4,
             n_occupied_extract=2,
             save_hamiltonian=True

--- a/src/python/qepsi4/_psi4_test.py
+++ b/src/python/qepsi4/_psi4_test.py
@@ -1,35 +1,35 @@
-import unittest
 from qepsi4 import run_psi4
 from openfermion import (
     jordan_wigner,
     jw_get_ground_state_at_particle_number,
     qubit_operator_sparse,
 )
+import numpy as np
+import math
 
 
-class TestChem(unittest.TestCase):
-    def test_run_psi4(self):
+def test_run_psi4(self):
 
-        geometry = {
-            "sites": [
-                {"species": "H", "x": 0, "y": 0, "z": 0},
-                {"species": "H", "x": 0, "y": 0, "z": 1.7},
-            ]
-        }
+    geometry = {
+        "sites": [
+            {"species": "H", "x": 0, "y": 0, "z": 0},
+            {"species": "H", "x": 0, "y": 0, "z": 1.7},
+        ]
+    }
 
-        results, hamiltonian = run_psi4(geometry, save_hamiltonian=True)
-        self.assertAlmostEqual(results["energy"], -0.8544322638069642)
-        self.assertEqual(results["n_alpha"], 1)
-        self.assertEqual(results["n_beta"], 1)
-        self.assertEqual(results["n_mo"], 2)
-        self.assertEqual(results["n_frozen_core"], 0)
-        self.assertEqual(results["n_frozen_valence"], 0)
+    results, hamiltonian = run_psi4(geometry, save_hamiltonian=True)
+    assert math.isclose(results["energy"], -0.8544322638069642)
+    assert results["n_alpha"] == 1
+    assert results["n_beta"] == 1
+    assert results["n_mo"] == 2
+    assert results["n_frozen_core"] == 0
+    assert results["n_frozen_valence"] == 0
 
-        self.assertEqual(hamiltonian.n_qubits, 4)
-        qubit_operator = qubit_operator_sparse(jordan_wigner(hamiltonian))
-        energy, state = jw_get_ground_state_at_particle_number(qubit_operator, 2)
+    assert hamiltonian.n_qubits == 4
+    qubit_operator = qubit_operator_sparse(jordan_wigner(hamiltonian))
+    energy, state = jw_get_ground_state_at_particle_number(qubit_operator, 2)
 
-        results_cisd, hamiltonian = run_psi4(geometry, method="ccsd")
+    results_cisd, hamiltonian = run_psi4(geometry, method="ccsd")
 
-        # For this system, the CCSD energy should be exact.
-        self.assertAlmostEqual(energy, results_cisd["energy"])
+    # For this system, the CCSD energy should be exact.
+    assert math.isclose(energy, results_cisd["energy"])

--- a/src/python/qepsi4/_psi4_test.py
+++ b/src/python/qepsi4/_psi4_test.py
@@ -1,30 +1,35 @@
 import unittest
 from qepsi4 import run_psi4
-from openfermion import (jordan_wigner, jw_get_ground_state_at_particle_number,
-                         qubit_operator_sparse)
+from openfermion import (
+    jordan_wigner,
+    jw_get_ground_state_at_particle_number,
+    qubit_operator_sparse,
+)
+
 
 class TestChem(unittest.TestCase):
-
     def test_run_psi4(self):
 
-        geometry = {"sites": [
-            {'species': 'H', 'x': 0, 'y': 0, 'z': 0},
-            {'species': 'H', 'x': 0, 'y': 0, 'z': 1.7}
-        ]}
+        geometry = {
+            "sites": [
+                {"species": "H", "x": 0, "y": 0, "z": 0},
+                {"species": "H", "x": 0, "y": 0, "z": 1.7},
+            ]
+        }
 
         results, hamiltonian = run_psi4(geometry, save_hamiltonian=True)
-        self.assertAlmostEqual(results['energy'], -0.8544322638069642)
-        self.assertEqual(results['n_alpha'], 1)
-        self.assertEqual(results['n_beta'], 1)
-        self.assertEqual(results['n_mo'], 2)
-        self.assertEqual(results['n_frozen_core'], 0)
-        self.assertEqual(results['n_frozen_valence'], 0)
+        self.assertAlmostEqual(results["energy"], -0.8544322638069642)
+        self.assertEqual(results["n_alpha"], 1)
+        self.assertEqual(results["n_beta"], 1)
+        self.assertEqual(results["n_mo"], 2)
+        self.assertEqual(results["n_frozen_core"], 0)
+        self.assertEqual(results["n_frozen_valence"], 0)
 
         self.assertEqual(hamiltonian.n_qubits, 4)
         qubit_operator = qubit_operator_sparse(jordan_wigner(hamiltonian))
         energy, state = jw_get_ground_state_at_particle_number(qubit_operator, 2)
-        
-        results_cisd, hamiltonian = run_psi4(geometry, method='ccsd')
+
+        results_cisd, hamiltonian = run_psi4(geometry, method="ccsd")
 
         # For this system, the CCSD energy should be exact.
-        self.assertAlmostEqual(energy, results_cisd['energy'])
+        self.assertAlmostEqual(energy, results_cisd["energy"])

--- a/src/python/qepsi4/_psi4_test.py
+++ b/src/python/qepsi4/_psi4_test.py
@@ -39,7 +39,7 @@ def test_run_psi4():
     results_cisd, hamiltonian = run_psi4(hydrogen_geometry, method="ccsd")
 
     # For this system, the CCSD energy should be exact.
-    assert math.isclose(energy, results_cisd["energy"])
+    assert math.isclose(energy, results_cisd["energy"], rel_tol=1e-7)
 
 
 def test_run_psi4_using_n_occupied_extract():
@@ -62,7 +62,7 @@ def test_run_psi4_n_occupied_extract_inconsistent_with_n_active_extract():
             basis="STO-3G",
             n_active_extract=2,
             n_occupied_extract=3,
-        save_hamiltonian=True
+            save_hamiltonian=True
         )
     except ValueError:
         pass
@@ -77,7 +77,7 @@ def test_run_psi4_n_occupied_extract_inconsistent_with_num_electrons():
             basis="STO-3G",
             n_active_extract=4,
             n_occupied_extract=2,
-        save_hamiltonian=True
+            save_hamiltonian=True
         )
     except ValueError:
         pass

--- a/src/python/qepsi4/_psi4_test.py
+++ b/src/python/qepsi4/_psi4_test.py
@@ -87,3 +87,15 @@ def test_run_psi4_n_occupied_extract_inconsistent_with_num_electrons():
         pass
     else:
         assert False
+
+def test_run_psi4_freeze_core_extract():
+    results, hamiltonian = run_psi4(
+            dilithium_geometry,
+            method="scf",
+            basis="STO-3G",
+            freeze_core=True,
+            freeze_core_extract=True,
+            save_hamiltonian=True
+        )
+
+    assert hamiltonian.n_qubits == 2*2*(1 + 3)

--- a/src/python/qepsi4/_psi4_test.py
+++ b/src/python/qepsi4/_psi4_test.py
@@ -6,6 +6,7 @@ from openfermion import (
 )
 import numpy as np
 import math
+import psi4
 
 hydrogen_geometry = {
     "sites": [
@@ -49,7 +50,7 @@ def test_run_psi4_using_n_occupied_extract():
         basis="STO-3G",
         n_active_extract=4,
         n_occupied_extract=2,
-        save_hamiltonian=True
+        save_hamiltonian=True,
     )
 
     assert hamiltonian.n_qubits == 8
@@ -57,6 +58,7 @@ def test_run_psi4_using_n_occupied_extract():
     qubit_operator = qubit_operator_sparse(jordan_wigner(hamiltonian))
     energy, state = jw_get_ground_state_at_particle_number(qubit_operator, 4)
     assert math.isclose(energy, -14.654620243980217)
+
 
 def test_run_psi4_n_occupied_extract_inconsistent_with_n_active_extract():
     try:
@@ -66,12 +68,13 @@ def test_run_psi4_n_occupied_extract_inconsistent_with_n_active_extract():
             basis="STO-3G",
             n_active_extract=2,
             n_occupied_extract=3,
-            save_hamiltonian=True
+            save_hamiltonian=True,
         )
     except ValueError:
         pass
     else:
         assert False
+
 
 def test_run_psi4_n_occupied_extract_inconsistent_with_num_electrons():
     try:
@@ -81,21 +84,25 @@ def test_run_psi4_n_occupied_extract_inconsistent_with_num_electrons():
             basis="6-31G",
             n_active_extract=4,
             n_occupied_extract=2,
-            save_hamiltonian=True
+            save_hamiltonian=True,
         )
     except ValueError:
         pass
     else:
         assert False
 
-def test_run_psi4_freeze_core_extract():
-    results, hamiltonian = run_psi4(
-            dilithium_geometry,
-            method="scf",
-            basis="STO-3G",
-            freeze_core=True,
-            freeze_core_extract=True,
-            save_hamiltonian=True
-        )
 
-    assert hamiltonian.n_qubits == 2*2*(1 + 3)
+def test_run_psi4_freeze_core_extract():
+    # For some reason, we must clean Psi4 before running this test if other
+    # tests have already run.
+    psi4.core.clean()
+    results, hamiltonian = run_psi4(
+        dilithium_geometry,
+        method="scf",
+        basis="STO-3G",
+        freeze_core=True,
+        freeze_core_extract=True,
+        save_hamiltonian=True,
+    )
+
+    assert hamiltonian.n_qubits == 2 * 2 * (1 + 3)

--- a/templates/psi4.yaml
+++ b/templates/psi4.yaml
@@ -21,6 +21,8 @@ spec:
         default: 'False'
       - name: n-active-extract
         default: None
+      - name: n-occupied-extract
+        default: None
       - name: freeze-core-extract
         default: 'False'
       - name: nthreads
@@ -67,6 +69,7 @@ spec:
                      save_hamiltonian={{inputs.parameters.save-hamiltonian}},
                      options={{inputs.parameters.options}},
                      n_active_extract={{inputs.parameters.n-active-extract}},
+                     n_occupied_extract={{inputs.parameters.n-occupied-extract}},
                      freeze_core_extract={{inputs.parameters.freeze-core-extract}})
             
             results['schema'] = SCHEMA_VERSION + '-energy_calc'


### PR DESCRIPTION
Adds the `n-occupied-extract` parameter, which allows the user to specifying how many occupied molecular orbitals should be extracted. Note that these count towards the total number of molecular orbitals to be extracted, specified by `n-active-extract`.