### PR TITLE
implemented 1- and 2-RDM calculation for CI methods (based on zmachine code) and added the unit tests for RDMs

### DIFF
--- a/src/python/qepsi4/__init__.py
+++ b/src/python/qepsi4/__init__.py
@@ -1,3 +1,3 @@
 """Psi4 integration for Quantum Engine."""
 
-from ._psi4 import run_psi4
+from ._psi4 import run_psi4, select_active_space

--- a/src/python/qepsi4/_psi4.py
+++ b/src/python/qepsi4/_psi4.py
@@ -151,11 +151,17 @@ def run_psi4(
     ndocc, nact, n_frozen_vir = select_active_space(molecule, fake_wfn, n_active_extract=n_active_extract, \
             n_occupied_extract=n_occupied_extract, freeze_core_extract=freeze_core_extract)
 
+    if ndocc != 0:
+        psi4.set_options({'frozen_docc' : ndocc})
+    if n_frozen_vir != 0:
+        psi4.set_options({'frozen_uocc' : n_frozen_vir})
+
     if method == 'fci' or method == 'cis' or method == 'cisd' or method == 'cisdt' or method == 'cisdtq':
         psi4.set_options({'qc_module' : 'detci' })
         if save_rdms:
             assert molecule.point_group().symbol() == 'c1' # otherwise frozen_docc and frozen_uocc should be arrays specifying number of orbitals per irrep
-            psi4.set_options({'opdm' : True, 'tpdm' : True, 'frozen_docc' : ndocc, 'frozen_uocc' : n_frozen_vir}) # this overrides freeze_core = True
+            #psi4.set_options({'opdm' : True, 'tpdm' : True, 'frozen_docc' : ndocc, 'frozen_uocc' : n_frozen_vir}) # this overrides freeze_core = True
+            psi4.set_options({'opdm' : True, 'tpdm' : True}) 
 
     energy, wavefunction = psi4.energy(method, return_wfn=True)
 

--- a/src/python/qepsi4/_psi4.py
+++ b/src/python/qepsi4/_psi4.py
@@ -141,7 +141,6 @@ def run_psi4(
     molecule = psi4.geometry(geometry_str)
 
     psi4.set_options(
-        #{"reference": reference, "basis": basis, "freeze_core": freeze_core, 'scf_type' : 'pk'}
         {"reference": reference, "basis": basis, "freeze_core": freeze_core}
     )
 
@@ -152,15 +151,14 @@ def run_psi4(
             n_occupied_extract=n_occupied_extract, freeze_core_extract=freeze_core_extract)
 
     if ndocc != 0:
-        psi4.set_options({'frozen_docc' : ndocc})
+        psi4.set_options({'num_frozen_docc' : ndocc})
     if n_frozen_vir != 0:
-        psi4.set_options({'frozen_uocc' : n_frozen_vir})
+        assert molecule.point_group().symbol() == 'c1' # otherwise frozen_uocc should be an array specifying number of orbitals per irrep
+        psi4.set_options({'frozen_uocc' : [n_frozen_vir]})
 
     if method == 'fci' or method == 'cis' or method == 'cisd' or method == 'cisdt' or method == 'cisdtq':
         psi4.set_options({'qc_module' : 'detci' })
         if save_rdms:
-            assert molecule.point_group().symbol() == 'c1' # otherwise frozen_docc and frozen_uocc should be arrays specifying number of orbitals per irrep
-            #psi4.set_options({'opdm' : True, 'tpdm' : True, 'frozen_docc' : ndocc, 'frozen_uocc' : n_frozen_vir}) # this overrides freeze_core = True
             psi4.set_options({'opdm' : True, 'tpdm' : True}) 
 
     energy, wavefunction = psi4.energy(method, return_wfn=True)

--- a/src/python/qepsi4/_psi4.py
+++ b/src/python/qepsi4/_psi4.py
@@ -1,6 +1,6 @@
 import psi4
 import numpy as np
-from openfermion import InteractionOperator, general_basis_change, MolecularData
+from openfermion import InteractionOperator, general_basis_change, MolecularData, InteractionRDM
 from openfermion.config import EQ_TOLERANCE
 
 
@@ -18,6 +18,7 @@ def run_psi4(
     n_active_extract=None,
     n_occupied_extract=None,
     freeze_core_extract=False,
+    save_rdms=False,
 ):
     """Generate an input file in the Psi4 python domain-specific language for
     a molecule.
@@ -42,6 +43,7 @@ def run_psi4(
         freeze_core_extract (bool): If True, frozen core orbitals will always be
             doubly occupied in the saved Hamiltonian. Ignored if
             n_occupied_extract is not None.
+        save_rdms (bool): If True, save 1- and 2-RDMs
         
     Returns:
         tuple: The results of the calculation (dict) and the Hamiltonian
@@ -53,6 +55,12 @@ def run_psi4(
             raise ValueError(
                 f"Number of occupied molecular orbitals to extract ({n_occupied_extract}) is larger than total number of molecular orbitals to extract ({n_active_extract})."
             )
+
+    if save_rdms and not method in ['fci', 'cis', 'cisd', 'cisdt', 'cisdtq']:
+        print(f"run_psi4 was called with method={method}")
+        raise Warning(
+            f"RDM calculation can only be performed for Configuration Interaction methods. save_rdms option will be ignored."
+        )
 
     geometry_str = f"{charge} {multiplicity}\n"
     for atom in geometry["sites"]:
@@ -69,6 +77,11 @@ def run_psi4(
     psi4.set_options(
         {"reference": reference, "basis": basis, "freeze_core": freeze_core}
     )
+    if method == 'fci' or method == 'cis' or method == 'cisd' or method == 'cisdt' or method == 'cisdtq':
+        psi4.set_options({'qc_module' : 'detci'})
+        if save_rdms:
+            psi4.set_options({'opdm' : True, 'tpdm' : True})
+
     energy, wavefunction = psi4.energy(method, return_wfn=True)
 
     results = {
@@ -111,9 +124,17 @@ def run_psi4(
             nuclear_repulsion_energy=molecule.nuclear_repulsion_energy(),
         )
 
-    psi4.core.clean()
-    return results, hamiltonian
-
+    if save_rdms:
+        rdm = get_rdms_from_psi4(wavefunction, freeze_core, n_active_extract, n_occupied_extract, freeze_core_extract)
+        psi4.core.clean()
+        psi4.core.clean_options()
+        psi4.core.clean_variables()
+        return results, hamiltonian, rdm
+    else:
+        psi4.core.clean()
+        psi4.core.clean_options()
+        psi4.core.clean_variables()
+        return results, hamiltonian
 
 def get_ham_from_psi4(
     wfn,
@@ -145,8 +166,7 @@ def get_ham_from_psi4(
     
     Returns:
         hamiltonian (openfermion.ops.InteractionOperator): the electronic
-            Hamiltonian. Note that the ion-ion electrostatic energy is not
-            included.
+            Hamiltonian.
     """
 
     assert wfn.same_a_b_orbs(), (
@@ -185,13 +205,13 @@ def get_ham_from_psi4(
 
     if n_active_extract is None:
         trf_mat = wfn.Ca()
-        n_active_extract = wfn.nmo() - n_core_extract
+        n_active_extract = wfn.nmo() - n_core_extract # - wfn.nfzvpi.sum() ?
     else:
         # If orbs is given, it allows us to perform the two-electron integrals
         # transformation only in the space of active orbitals. Otherwise, we
         # transform all orbitals and filter them out in the get_ham_from_integrals
         # function
-        if orbs is None:
+        if orbs is None: # If n_acitve_extract is not None - how could possibly be orbs == None?
             trf_mat = wfn.Ca()
         else:
             assert (
@@ -231,3 +251,164 @@ def get_ham_from_psi4(
     )
 
     return hamiltonian
+
+def get_rdms_from_psi4(wfn, 
+    freeze_core,
+    n_active_extract=None, 
+    n_occupied_extract=None,
+    freeze_core_extract=False):
+    """
+    Args:
+        wfn (psi4.core.Wavefunction): Psi4 wavefunction object
+        freeze_core (bool): Whether to freeze occupied core orbitals
+        n_active_extract (int): number of molecular orbitals to include in the
+            saved Hamiltonian. If None, includes all orbitals, else you must provide
+            active orbitals in orbs.
+        n_occupied_extract (int): number of occupied molecular orbitals to
+            include in the saved Hamiltonian. Must be less than or equal to
+            n_active_extract. If None, all occupied orbitals are included,
+            except the core orbitals if freeze_core_extract is set to True.
+        freeze_core_extract (bool): If True, frozen core orbitals will always be
+            doubly occupied in the saved Hamiltonian. Ignored if
+            n_occupied_extract is not None.
+    Returns:
+        rdm (openfermion.ops.InteractionRDM): an openfermion object storing
+            1- and 2-RDMs. 
+    """
+
+    one_rdm_a = np.array(wfn.get_opdm(
+        0, 0, 'A', True)).reshape(wfn.nmo(), wfn.nmo()) # Note: this works even if freeze_core is True
+    one_rdm_b = np.array(wfn.get_opdm(
+        0, 0, 'B', True)).reshape(wfn.nmo(), wfn.nmo())
+
+    # Get 2-RDM from CI calculation.
+    n_core_extract = 0
+    if freeze_core_extract and n_occupied_extract is None:
+        n_core_extract = wfn.nfrzc() # This logic implies that cores are always the lowest energy orbitals.
+    elif n_occupied_extract is not None:
+        if wfn.nalpha() != wfn.nbeta():
+            raise ValueError(
+                f"Requesting a number of occupied molecular orbitals not supported when number of alpha and beta electrons is unequal."
+            )
+        if n_occupied_extract > wfn.nalpha():
+            raise ValueError(
+                f"Number of occupied molecular orbitals to extract ({n_occupied_extract}) is larger than number of occupied molecular orbitals ({wfn.nalpha()})."
+            )
+
+        n_core_extract = wfn.nalpha() - n_occupied_extract
+
+    if n_active_extract is None:
+        n_active_extract = wfn.nmo() - n_core_extract
+    
+    nfnmo = wfn.nmo() - wfn.frzcpi().sum() - wfn.frzvpi().sum() # I wouldn't work otherwise for 2-RDMs
+
+    two_rdm_aa = np.array(wfn.get_tpdm(
+        'AA', False)).reshape(nfnmo, nfnmo,
+                                nfnmo, nfnmo)
+    two_rdm_ab = np.array(wfn.get_tpdm(
+        'AB', False)).reshape(nfnmo, nfnmo,
+                                nfnmo, nfnmo)
+    two_rdm_bb = np.array(wfn.get_tpdm(
+        'BB', False)).reshape(nfnmo, nfnmo,
+                                nfnmo, nfnmo)
+
+    # Indices of active molecular orbitals
+    active_indices = range(n_core_extract, n_core_extract + n_active_extract)
+
+    # adjusting 1-RDM
+    one_rdm_a = one_rdm_a[np.ix_(active_indices, active_indices)]
+    one_rdm_b = one_rdm_b[np.ix_(active_indices, active_indices)]
+    
+    if freeze_core:
+        active_indices = range(n_active_extract) # Need to double check if this actually works
+    # If one also requested freeze_core_extract => we need to construct and save RHF RDMs for the core
+
+    # adjusting 2-RDM
+    two_rdm_aa = two_rdm_aa[np.ix_(active_indices,
+                                  active_indices,
+                                  active_indices,
+                                  active_indices)]
+    two_rdm_ab = two_rdm_ab[np.ix_(active_indices,
+                                  active_indices,
+                                  active_indices,
+                                  active_indices)]
+    two_rdm_bb = two_rdm_bb[np.ix_(active_indices,
+                                   active_indices,
+                                   active_indices,
+                                   active_indices)]
+
+    one_rdm, two_rdm = unpack_spatial_rdm(
+    one_rdm_a, one_rdm_b, two_rdm_aa,
+    two_rdm_ab, two_rdm_bb)
+
+    rdms = InteractionRDM(one_rdm, two_rdm)
+
+    return rdms
+
+def unpack_spatial_rdm(one_rdm_a,
+                       one_rdm_b,
+                       two_rdm_aa,
+                       two_rdm_ab,
+                       two_rdm_bb):
+    r"""
+    Covert from spin compact spatial format to spin-orbital format for RDM.
+    Note: the compact 2-RDM is stored as follows where A/B are spin up/down:
+    RDM[pqrs] = <| a_{p, A}^\dagger a_{r, A}^\dagger a_{q, A} a_{s, A} |>
+      for 'AA'/'BB' spins.
+    RDM[pqrs] = <| a_{p, A}^\dagger a_{r, B}^\dagger a_{q, B} a_{s, A} |>
+      for 'AB' spins.
+    Args:
+        one_rdm_a: 2-index numpy array storing alpha spin
+            sector of 1-electron reduced density matrix.
+        one_rdm_b: 2-index numpy array storing beta spin
+            sector of 1-electron reduced density matrix.
+        two_rdm_aa: 4-index numpy array storing alpha-alpha spin
+            sector of 2-electron reduced density matrix.
+        two_rdm_ab: 4-index numpy array storing alpha-beta spin
+            sector of 2-electron reduced density matrix.
+        two_rdm_bb: 4-index numpy array storing beta-beta spin
+            sector of 2-electron reduced density matrix.
+    Returns:
+        one_rdm: 2-index numpy array storing 1-electron density matrix
+            in full spin-orbital space.
+        two_rdm: 4-index numpy array storing 2-electron density matrix
+            in full spin-orbital space.
+    """
+    # Initialize RDMs.
+    n_orbitals = one_rdm_a.shape[0]
+    n_qubits = 2 * n_orbitals
+    one_rdm = np.zeros((n_qubits, n_qubits))
+    two_rdm = np.zeros((n_qubits, n_qubits,
+                           n_qubits, n_qubits))
+
+    # Unpack compact representation.
+    for p in range(n_orbitals):
+        for q in range(n_orbitals):
+
+            # Populate 1-RDM.
+            one_rdm[2 * p, 2 * q] = one_rdm_a[p, q]
+            one_rdm[2 * p + 1, 2 * q + 1] = one_rdm_b[p, q]
+
+            # Continue looping to unpack 2-RDM.
+            for r in range(n_orbitals):
+                for s in range(n_orbitals):
+
+                    # Handle case of same spin.
+                    two_rdm[2 * p, 2 * q, 2 * r, 2 * s] = (
+                        two_rdm_aa[p, r, q, s])
+                    two_rdm[2 * p + 1, 2 * q + 1, 2 * r + 1, 2 * s + 1] = (
+                        two_rdm_bb[p, r, q, s])
+
+                    # Handle case of mixed spin.
+                    two_rdm[2 * p, 2 * q + 1, 2 * r, 2 * s + 1] = (
+                        two_rdm_ab[p, r, q, s])
+                    two_rdm[2 * p, 2 * q + 1, 2 * r + 1, 2 * s] = (
+                        -1. * two_rdm_ab[p, s, q, r])
+                    two_rdm[2 * p + 1, 2 * q, 2 * r + 1, 2 * s] = (
+                        two_rdm_ab[q, s, p, r])
+                    two_rdm[2 * p + 1, 2 * q, 2 * r, 2 * s + 1] = (
+                        -1. * two_rdm_ab[q, r, p, s])
+
+    # Map to physicist notation and return.
+    two_rdm = np.einsum('pqsr', two_rdm)
+    return one_rdm, two_rdm

--- a/src/python/qepsi4/_psi4.py
+++ b/src/python/qepsi4/_psi4.py
@@ -85,7 +85,6 @@ def run_psi4(
     method: str = "scf",
     reference: str = "rhf",
     freeze_core: bool = False,
-    n_active: int = None,
     save_hamiltonian: bool = False,
     options: dict = None,
     n_active_extract: int = None,
@@ -104,7 +103,6 @@ def run_psi4(
         method: which calculation method to use
         reference: which reference wavefunction to use. fno- energy methods are only compatible with RHF
         freeze_core: Whether to freeze occupied core orbitals
-        n_active: Number of active orbitals. Freeze virtual orbitals that do not fit on the qubits.
         save_hamiltonian: whether to save the Hamiltonian to a file. If True, symmetry will be disabled.
         options: additional commands to be passed to Psi4
         n_active_extract: number of molecular orbitals to include in the

--- a/src/python/qepsi4/_psi4_test.py
+++ b/src/python/qepsi4/_psi4_test.py
@@ -23,6 +23,14 @@ dilithium_geometry = {
 }
 
 
+water_geometry = {
+    "sites": [
+        {"species": "O", "x": 0, "y": 0, "z": -0.0454827817},
+        {"species": "H", "x": -0.7634678739, "y": 0, "z": 0.5512397709},
+        {"species": "H", "x":  0.7634678739, "y": 0, "z": 0.5512397709},
+    ]
+}
+
 def test_run_psi4():
 
     results, hamiltonian = run_psi4(hydrogen_geometry, save_hamiltonian=True)
@@ -42,6 +50,19 @@ def test_run_psi4():
     # For this system, the CCSD energy should be exact.
     assert math.isclose(energy, results_cisd["energy"], rel_tol=1e-7)
 
+def test_get_rdms_from_psi4():
+
+    results, hamiltonian, rdm = run_psi4(hydrogen_geometry, method='fci', basis='STO-3G', save_hamiltonian=True, save_rdms=True)
+    energy_from_rdm = rdm.expectation(hamiltonian)
+    assert math.isclose(results["energy"], energy_from_rdm)
+    assert results["n_alpha"] == 1 and results["n_beta"] == 1 and results["n_mo"] == 2\
+                    and results["n_frozen_core"] == 0 and results["n_frozen_valence"] == 0 and hamiltonian.n_qubits == 4
+
+    assert hamiltonian.n_qubits == 4
+    qubit_operator = qubit_operator_sparse(jordan_wigner(hamiltonian))
+    energy, state = jw_get_ground_state_at_particle_number(qubit_operator, 2)
+
+    assert math.isclose(energy, energy_from_rdm)
 
 def test_run_psi4_using_n_occupied_extract():
     results, hamiltonian = run_psi4(
@@ -59,6 +80,25 @@ def test_run_psi4_using_n_occupied_extract():
     energy, state = jw_get_ground_state_at_particle_number(qubit_operator, 4)
     assert math.isclose(energy, -14.654620243980217)
 
+def test_run_psi4_using_n_occupied_extract_with_rdms():
+    results, hamiltonian, rdm = run_psi4(
+        dilithium_geometry,
+        method="fci",
+        basis="STO-3G",
+        n_active_extract=4,
+        n_occupied_extract=2,
+        save_hamiltonian=True,
+        save_rdms=True,
+    )
+
+    assert hamiltonian.n_qubits == 8
+    assert rdm.one_body_tensor.shape[0] == 8
+
+    qubit_operator = qubit_operator_sparse(jordan_wigner(hamiltonian))
+    energy, state = jw_get_ground_state_at_particle_number(qubit_operator, 4)
+
+    energy_from_rdm = rdm.expectation(hamiltonian)
+    assert energy <= energy_from_rdm
 
 def test_run_psi4_n_occupied_extract_inconsistent_with_n_active_extract():
     try:
@@ -107,3 +147,25 @@ def test_run_psi4_freeze_core_extract():
 
     # With STO-3G, each Li atom has one 1s orbital, one 2s orbital, and three 2p orbitals. The 1s orbitals are considered core orbitals.
     assert hamiltonian.n_qubits == 2 * 2 * (1 + 3)
+
+
+def test_run_psi4_freeze_core_extract_and_rdms():
+    # For some reason, we must clean Psi4 before running this test if other
+    # tests have already run.
+    psi4.core.clean()
+    results, hamiltonian, rdm = run_psi4(
+        dilithium_geometry,
+        method="fci",
+        basis="STO-3G",
+        freeze_core=True,
+        freeze_core_extract=True,
+        save_hamiltonian=True,
+        save_rdms=True
+    )
+
+    # With STO-3G, each Li atom has one 1s orbital, one 2s orbital, and three 2p orbitals. The 1s orbitals are considered core orbitals.
+    assert hamiltonian.n_qubits == 2 * 2 * (1 + 3)
+    assert rdm.one_body_tensor.shape[0] == 2 * 2 * (1 + 3)
+
+    energy_from_rdm = rdm.expectation(hamiltonian)
+    assert math.isclose(results["energy"], energy_from_rdm)

--- a/src/python/qepsi4/_psi4_test.py
+++ b/src/python/qepsi4/_psi4_test.py
@@ -139,7 +139,8 @@ def test_run_psi4_1():
     qubit_operator = qubit_operator_sparse(jordan_wigner(hamiltonian))
     energy, state = jw_get_ground_state_at_particle_number(qubit_operator, 2) # This should give RHF energy
 
-    assert math.isclose(energy, results["energy"], rel_tol=1e-3) # Note: this test only passes if rel_tol=1e-3 or lower; we should investigate this
+    assert math.isclose(energy, results["energy"], rel_tol=1e-3) # since the energy is calculated with scf_type df by default, the test fails for a lower rel_tol
+    #assert math.isclose(energy, results["energy"])
 
 def test_run_psi4_2():
 
@@ -155,7 +156,8 @@ def test_run_psi4_2():
     qubit_operator = qubit_operator_sparse(jordan_wigner(hamiltonian))
     energy, state = jw_get_ground_state_at_particle_number(qubit_operator, 0) # This should give RHF energy in the 0-particle sector of the Fock space
 
-    assert math.isclose(energy, results["energy"], rel_tol=1e-3) # Note: same as the previous test; it is not affected by EQ_TOLERANCE and could be due to a bug in the OpenFermion
+    assert math.isclose(energy, results["energy"], rel_tol=1e-3) # since the energy is calculated with scf_type df by default, the test fails for a lower rel_tol
+    #assert math.isclose(energy, results["energy"])
 
 def test_get_rdms_from_psi4_0():
 

--- a/src/python/qepsi4/_psi4_test.py
+++ b/src/python/qepsi4/_psi4_test.py
@@ -1,4 +1,4 @@
-from qepsi4 import run_psi4
+from qepsi4 import select_active_space, run_psi4
 from openfermion import (
     jordan_wigner,
     jw_get_ground_state_at_particle_number,
@@ -31,7 +31,82 @@ water_geometry = {
     ]
 }
 
-def test_run_psi4():
+
+def create_molecule(geometry, charge, mult):
+
+    geometry_str = f"{charge} {mult}\n"
+    for atom in geometry["sites"]:
+        geometry_str += "{} {} {} {}\n".format(
+            atom["species"], atom["x"], atom["y"], atom["z"]
+        )
+
+    geometry_str += "\nunits angstrom\n"
+    geometry_str += "symmetry c1\n"
+
+    molecule = psi4.geometry(geometry_str)
+
+    return molecule
+
+
+def test_active_space_0():
+
+    h2 = create_molecule(hydrogen_geometry, charge=0, mult=1)
+    psi4.set_options({"basis": 'sto-3g'})
+    fake_wfn = psi4.core.Wavefunction.build(h2, psi4.core.get_global_option('basis')) 
+
+    ndocc, nact, nvir = select_active_space(h2, fake_wfn, n_active_extract=2)
+
+    assert ndocc == 0
+    assert nact == 2
+    assert nvir == 0
+
+    psi4.core.clean()
+    psi4.core.clean_options()
+    psi4.core.clean_variables()
+
+def test_active_space_1():
+
+    h2o = create_molecule(water_geometry, charge=0, mult=1)
+    psi4.set_options({"basis": 'sto-3g'})
+    fake_wfn = psi4.core.Wavefunction.build(h2o, psi4.core.get_global_option('basis')) 
+
+    # Active space specs
+
+    ndocc, nact, nvir = select_active_space(h2o, fake_wfn, n_active_extract=2)
+
+    assert ndocc == 0
+    assert nact == 2
+    assert nvir == 5
+
+    ndocc, nact, nvir = select_active_space(h2o, fake_wfn)
+
+    assert ndocc == 0
+    assert nact == 7
+    assert nvir == 0
+
+    ndocc, nact, nvir = select_active_space(h2o, fake_wfn, freeze_core_extract=True)
+
+    assert ndocc == 1
+    assert nact == 6
+    assert nvir == 0
+
+    ndocc, nact, nvir = select_active_space(h2o, fake_wfn, n_occupied_extract = 3, freeze_core_extract=True)
+
+    assert ndocc == 2
+    assert nact == 5
+    assert nvir == 0
+
+    ndocc, nact, nvir = select_active_space(h2o, fake_wfn, n_active_extract = 4, n_occupied_extract = 3)
+
+    assert ndocc == 2
+    assert nact == 4
+    assert nvir == 1
+
+    psi4.core.clean()
+    psi4.core.clean_options()
+    psi4.core.clean_variables()
+
+def test_run_psi4_0():
 
     results, hamiltonian = run_psi4(hydrogen_geometry, save_hamiltonian=True)
     assert math.isclose(results["energy"], -0.8544322638069642)
@@ -50,20 +125,55 @@ def test_run_psi4():
     # For this system, the CCSD energy should be exact.
     assert math.isclose(energy, results_cisd["energy"], rel_tol=1e-7)
 
-def test_get_rdms_from_psi4():
+def test_run_psi4_1():
+
+    results, hamiltonian = run_psi4(hydrogen_geometry, save_hamiltonian=True, n_active_extract=1)
+    assert math.isclose(results["energy"], -0.8544322638069642)
+    assert results["n_alpha"] == 1
+    assert results["n_beta"] == 1
+    assert results["n_mo"] == 2
+    assert results["n_frozen_core"] == 0
+    assert results["n_frozen_valence"] == 0
+
+    assert hamiltonian.n_qubits == 2
+    qubit_operator = qubit_operator_sparse(jordan_wigner(hamiltonian))
+    energy, state = jw_get_ground_state_at_particle_number(qubit_operator, 2) # This should give RHF energy
+
+    assert math.isclose(energy, results["energy"], rel_tol=1e-3) # Note: this test only passes if rel_tol=1e-3 or lower; we should investigate this
+
+def test_run_psi4_2():
+
+    results, hamiltonian = run_psi4(hydrogen_geometry, save_hamiltonian=True, n_active_extract=1, n_occupied_extract=0)
+    assert math.isclose(results["energy"], -0.8544322638069642)
+    assert results["n_alpha"] == 1
+    assert results["n_beta"] == 1
+    assert results["n_mo"] == 2
+    assert results["n_frozen_core"] == 0
+    assert results["n_frozen_valence"] == 0
+
+    assert hamiltonian.n_qubits == 2
+    qubit_operator = qubit_operator_sparse(jordan_wigner(hamiltonian))
+    energy, state = jw_get_ground_state_at_particle_number(qubit_operator, 0) # This should give RHF energy in the 0-particle sector of the Fock space
+
+    assert math.isclose(energy, results["energy"], rel_tol=1e-3) # Note: same as the previous test; it is not affected by EQ_TOLERANCE and could be due to a bug in the OpenFermion
+
+def test_get_rdms_from_psi4_0():
 
     results, hamiltonian, rdm = run_psi4(hydrogen_geometry, method='fci', basis='STO-3G', save_hamiltonian=True, save_rdms=True)
     energy_from_rdm = rdm.expectation(hamiltonian)
     assert math.isclose(results["energy"], energy_from_rdm)
     assert results["n_alpha"] == 1 and results["n_beta"] == 1 and results["n_mo"] == 2\
-                    and results["n_frozen_core"] == 0 and results["n_frozen_valence"] == 0 and hamiltonian.n_qubits == 4
+                    and results["n_frozen_core"] == 0 and results["n_frozen_valence"] == 0
 
     assert hamiltonian.n_qubits == 4
+    assert math.isclose(np.einsum("ii->", rdm.one_body_tensor), 2)
+    
     qubit_operator = qubit_operator_sparse(jordan_wigner(hamiltonian))
     energy, state = jw_get_ground_state_at_particle_number(qubit_operator, 2)
 
     assert math.isclose(energy, energy_from_rdm)
 
+    
 def test_run_psi4_using_n_occupied_extract():
     results, hamiltonian = run_psi4(
         dilithium_geometry,
@@ -77,28 +187,51 @@ def test_run_psi4_using_n_occupied_extract():
     assert hamiltonian.n_qubits == 8
 
     qubit_operator = qubit_operator_sparse(jordan_wigner(hamiltonian))
-    energy, state = jw_get_ground_state_at_particle_number(qubit_operator, 4)
+    energy, state = jw_get_ground_state_at_particle_number(qubit_operator, 4) 
     assert math.isclose(energy, -14.654620243980217)
 
-def test_run_psi4_using_n_occupied_extract_with_rdms():
+def test_run_psi4_using_n_occupied_extract_with_rdms_0():
     results, hamiltonian, rdm = run_psi4(
         dilithium_geometry,
         method="fci",
         basis="STO-3G",
         n_active_extract=4,
-        n_occupied_extract=2,
+        n_occupied_extract=1,
         save_hamiltonian=True,
         save_rdms=True,
     )
 
     assert hamiltonian.n_qubits == 8
     assert rdm.one_body_tensor.shape[0] == 8
+    assert math.isclose(np.einsum("ii->", rdm.one_body_tensor), 2)
 
     qubit_operator = qubit_operator_sparse(jordan_wigner(hamiltonian))
-    energy, state = jw_get_ground_state_at_particle_number(qubit_operator, 4)
+    energy, state = jw_get_ground_state_at_particle_number(qubit_operator, 2)
 
     energy_from_rdm = rdm.expectation(hamiltonian)
-    assert energy <= energy_from_rdm
+    assert math.isclose(energy, energy_from_rdm)
+
+#def test_run_psi4_using_n_occupied_extract_with_rdms_1():
+#    results, hamiltonian, rdm = run_psi4(
+#        dilithium_geometry,
+#        method="fci",
+#        basis="STO-3G",
+#        freeze_core=True,
+#        n_active_extract=4,
+#        n_occupied_extract=0,
+#        save_hamiltonian=True,
+#        save_rdms=True,
+#    )
+#
+#    assert hamiltonian.n_qubits == 8
+#    assert rdm.one_body_tensor.shape[0] == 8
+#    assert np.einsum("ii->", rdm.one_body_tensor) == 0
+#
+#    qubit_operator = qubit_operator_sparse(jordan_wigner(hamiltonian))
+#    energy, state = jw_get_ground_state_at_particle_number(qubit_operator, 0)
+#
+#    energy_from_rdm = rdm.expectation(hamiltonian)
+#    assert energy <= energy_from_rdm
 
 def test_run_psi4_n_occupied_extract_inconsistent_with_n_active_extract():
     try:

--- a/src/python/qepsi4/_psi4_test.py
+++ b/src/python/qepsi4/_psi4_test.py
@@ -211,6 +211,8 @@ def test_run_psi4_using_n_occupied_extract_with_rdms_0():
     energy_from_rdm = rdm.expectation(hamiltonian)
     assert math.isclose(energy, energy_from_rdm)
 
+# This test may not play well with Psi4 because of 0 electrons in FCI, so I commented it
+# out for now.
 #def test_run_psi4_using_n_occupied_extract_with_rdms_1():
 #    results, hamiltonian, rdm = run_psi4(
 #        dilithium_geometry,
@@ -299,6 +301,7 @@ def test_run_psi4_freeze_core_extract_and_rdms():
     # With STO-3G, each Li atom has one 1s orbital, one 2s orbital, and three 2p orbitals. The 1s orbitals are considered core orbitals.
     assert hamiltonian.n_qubits == 2 * 2 * (1 + 3)
     assert rdm.one_body_tensor.shape[0] == 2 * 2 * (1 + 3)
+    assert math.isclose(np.einsum("ii->", rdm.one_body_tensor), 2)
 
     energy_from_rdm = rdm.expectation(hamiltonian)
     assert math.isclose(results["energy"], energy_from_rdm)

--- a/src/python/qepsi4/_psi4_test.py
+++ b/src/python/qepsi4/_psi4_test.py
@@ -133,7 +133,7 @@ def test_run_psi4_1():
     assert results["n_beta"] == 1
     assert results["n_mo"] == 2
     assert results["n_frozen_core"] == 0
-    assert results["n_frozen_valence"] == 0
+    assert results["n_frozen_valence"] == 1
 
     assert hamiltonian.n_qubits == 2
     qubit_operator = qubit_operator_sparse(jordan_wigner(hamiltonian))
@@ -149,7 +149,7 @@ def test_run_psi4_2():
     assert results["n_alpha"] == 1
     assert results["n_beta"] == 1
     assert results["n_mo"] == 2
-    assert results["n_frozen_core"] == 0
+    assert results["n_frozen_core"] == 1
     assert results["n_frozen_valence"] == 0
 
     assert hamiltonian.n_qubits == 2


### PR DESCRIPTION
The branch contains a modified version of `run_psi4` function that implements 1- and 2-RDM calculation (FCI, CISD, CISDT, CISDTQ) based on z-machine code. RDMs are requested by passing `save_rdms=True` to `run_psi4` in which case it returns `results, hamiltonian, rdm` with the latter being an Openfermion InteractionRDM object. RDMs can be used to perform a more accurate measurement analysis for chemical Hamiltonians. 