### PR TITLE
Updated qe-psi4 tests

### DIFF
--- a/src/python/qepsi4/_psi4.py
+++ b/src/python/qepsi4/_psi4.py
@@ -135,7 +135,7 @@ def run_psi4(
         )
 
     geometry_str += "\nunits angstrom\n"
-    c1_sym = save_hamiltonian # or n_active
+    c1_sym = save_hamiltonian or save_rdms
     if c1_sym:
         geometry_str += "symmetry c1\n"
 


### PR DESCRIPTION
The branch implements a minor update of the `qe-psi4` tests (please refer to the tracker story https://www.pivotaltracker.com/story/show/175753088 for more details) and fixes a bug in `run_psi4` that cased RDM extraction to fail unless `save_hamiltonian = True` (there is also a test for that now).