### PR TITLE
Working run-psi4 template

### DIFF
--- a/src/python/qepsi4/_psi4.py
+++ b/src/python/qepsi4/_psi4.py
@@ -140,8 +140,9 @@ def run_psi4(
     if save_rdms and not method in ["fci", "cis", "cisd", "cisdt", "cisdtq"]:
         print(f"run_psi4 was called with method={method}")
         warnings.warn(
-            "RDM calculation can only be performed for Configuration Interaction methods. save_rdms option will be ignored."
+            "RDM calculation can only be performed for Configuration Interaction methods. save_rdms option will be set to False."
         )
+        save_rdms = False
 
     geometry_str = f"{charge} {multiplicity}\n"
     for atom in geometry["sites"]:

--- a/templates/psi4.yaml
+++ b/templates/psi4.yaml
@@ -106,6 +106,9 @@ spec:
       - name: hamiltonian
         path: /app/hamiltonian.json
         optional: True
+      - name: rdms
+        path: /app/rdms.json
+        optional: True
       parameters:
       - name: n-alpha
         valueFrom:

--- a/templates/psi4.yaml
+++ b/templates/psi4.yaml
@@ -52,7 +52,7 @@ spec:
           data: |
             import os, json
             from qepsi4 import run_psi4
-            from qeopenfermion import save_interaction_operator
+            from qeopenfermion import save_interaction_operator, save_interaction_rdm
             from zquantum.core.utils import SCHEMA_VERSION
 
             with open('geometry.json') as f:


### PR DESCRIPTION
PR implements a bugfix for the `run-psi4` v0 template and changes the behavior of `run_psi4` function when `save_rdms=True` with non-CI methods. 