### PR TITLE
Updating psi4 step to accept dict inputs

### DIFF
--- a/steps/run_psi4_calculations.py
+++ b/steps/run_psi4_calculations.py
@@ -31,7 +31,8 @@ def run_psi4(
     if options == "None":
         options = None
     else:
-        options = json.loads(options)
+        if isinstance(options, str):
+            options = json.loads(options)
     if wavefunction == "None":
         wavefunction = None
 


### PR DESCRIPTION
Allows `options` input to be provided as a dict instead of string when using `qe-psi4` in a workflow.