### PR TITLE
Feature dockerfile cleanup

### DIFF
--- a/docker/stable/Dockerfile
+++ b/docker/stable/Dockerfile
@@ -3,38 +3,28 @@
 FROM ubuntu
 WORKDIR /app
 USER root
-RUN apt-get update --ignore-missing
+
+ARG PSI4_VERSION="Psi4conda-1.4rc2-py37-Linux-x86_64"
 
 # Install python, pip, and other utilities
-RUN yes | apt-get install wget
-RUN yes | apt-get install git
-RUN yes | apt-get install python3
-RUN yes | apt-get install python3-pip
-RUN yes | apt-get install vim
-RUN apt-get -y install htop
-
-# Install development stuff. Not sure if all of these things are necessary.
-RUN yes | apt-get install gcc
-RUN yes | apt-get install g++
-RUN yes | apt-get install python-dev
+RUN apt-get update --ignore-missing && \
+    apt-get install wget git python3 python3-pip python-dev vim htop curl
 
 # Install Psi4
-RUN apt-get install -y curl
 WORKDIR /root
-RUN curl "http://vergil.chemistry.gatech.edu/psicode-download/Psi4conda-1.3.2-py37-Linux-x86_64.sh" -o Psi4conda-1.3.2-py37-Linux-x86_64.sh --keepalive-time 2
-RUN bash Psi4conda-1.3.2-py37-Linux-x86_64.sh -b -p $HOME/psi4conda
-RUN echo '. $HOME/psi4conda/etc/profile.d/conda.sh' >> ~/.bashrc
-RUN echo 'conda activate' >> ~/.bashrc
-RUN rm /root/Psi4conda-1.3.2-py37-Linux-x86_64.sh
+RUN curl "http://vergil.chemistry.gatech.edu/psicode-download/${PSI4_VERSION}.sh" -o ${PSI4_VERSION}.sh --keepalive-time 2 && \
+    bash ${PSI4_VERSION}.sh -b -p $HOME/psi4conda && \
+    echo ". $HOME/psi4conda/etc/profile.d/conda.sh\nconda activate" >> ~/.bashrc && \ 
+    rm /root/${PSI4_VERSION}.sh
 
 ENV PATH="/root/psi4conda/bin:${PATH}"
 ENV PYTHONPATH="/usr/local/lib/python3.7/dist-packages:${PYTHONPATH}"
 
 RUN python3 -m pip install scipy==1.2.2 \
-                           numpy==1.15.4 \
-                           openfermion==0.10.0 \
-                           pyyaml==5.1 \
-                           python-rapidjson==0.9.1
+    numpy==1.15.4 \
+    openfermion==0.10.0 \
+    pyyaml==5.1 \
+    python-rapidjson==0.9.1
 
 WORKDIR /app
 

--- a/docker/stable/Dockerfile
+++ b/docker/stable/Dockerfile
@@ -8,7 +8,7 @@ ARG PSI4_VERSION="Psi4conda-1.3.2-py37-Linux-x86_64"
 
 # Install python, pip, and other utilities
 RUN apt-get update -y --ignore-missing && \
-    apt-get install -y curl
+    apt-get install -y curl git
 
 # Install Psi4
 RUN curl "http://vergil.chemistry.gatech.edu/psicode-download/${PSI4_VERSION}.sh" -o /root/${PSI4_VERSION}.sh --keepalive-time 2 && \

--- a/docker/stable/Dockerfile
+++ b/docker/stable/Dockerfile
@@ -4,21 +4,20 @@ FROM ubuntu
 WORKDIR /app
 USER root
 
-ARG PSI4_VERSION="Psi4conda-1.4rc2-py37-Linux-x86_64"
+ARG PSI4_VERSION="Psi4conda-1.3.2-py37-Linux-x86_64"
 
 # Install python, pip, and other utilities
-RUN apt-get update --ignore-missing && \
-    apt-get install wget git python3 python3-pip python-dev vim htop curl
+RUN apt-get update -y --ignore-missing && \
+    apt-get install -y curl
 
 # Install Psi4
-WORKDIR /root
-RUN curl "http://vergil.chemistry.gatech.edu/psicode-download/${PSI4_VERSION}.sh" -o ${PSI4_VERSION}.sh --keepalive-time 2 && \
-    bash ${PSI4_VERSION}.sh -b -p $HOME/psi4conda && \
+RUN curl "http://vergil.chemistry.gatech.edu/psicode-download/${PSI4_VERSION}.sh" -o /root/${PSI4_VERSION}.sh --keepalive-time 2 && \
+    bash /root/${PSI4_VERSION}.sh -b -p $HOME/psi4conda && \
     echo ". $HOME/psi4conda/etc/profile.d/conda.sh\nconda activate" >> ~/.bashrc && \ 
     rm /root/${PSI4_VERSION}.sh
 
 ENV PATH="/root/psi4conda/bin:${PATH}"
-ENV PYTHONPATH="/usr/local/lib/python3.7/dist-packages:${PYTHONPATH}"
+ENV PYTHONPATH="/root/psi4conda/lib/python3.7/site-packages:/usr/local/lib/python3.7/dist-packages:${PYTHONPATH}"
 
 RUN python3 -m pip install scipy==1.2.2 \
     numpy==1.15.4 \

--- a/docker/stable/Dockerfile
+++ b/docker/stable/Dockerfile
@@ -19,12 +19,15 @@ RUN curl "http://vergil.chemistry.gatech.edu/psicode-download/${PSI4_VERSION}.sh
 ENV PATH="/root/psi4conda/bin:${PATH}"
 ENV PYTHONPATH="/root/psi4conda/lib/python3.7/site-packages:/usr/local/lib/python3.7/dist-packages:${PYTHONPATH}"
 
+RUN rm -r /root/psi4conda/lib/python3.7/site-packages/ruamel*
+
 RUN python3 -m pip install --upgrade pip==20.2.4 && \ 
     python3 -m pip install scipy==1.2.2 \
     numpy==1.15.4 \
     openfermion==0.10.0 \
     pyyaml==5.1 \
-    python-rapidjson==0.9.1
+    python-rapidjson==0.9.1 \
+    ruamel.yaml==0.17.10
 
 WORKDIR /app
 

--- a/docker/stable/Dockerfile
+++ b/docker/stable/Dockerfile
@@ -8,7 +8,7 @@ ARG PSI4_VERSION="Psi4conda-1.3.2-py37-Linux-x86_64"
 
 # Install python, pip, and other utilities
 RUN apt-get update -y --ignore-missing && \
-    apt-get install -y curl git
+    apt-get install -y curl git gcc g++
 
 # Install Psi4
 RUN curl "http://vergil.chemistry.gatech.edu/psicode-download/${PSI4_VERSION}.sh" -o /root/${PSI4_VERSION}.sh --keepalive-time 2 && \

--- a/docker/stable/Dockerfile
+++ b/docker/stable/Dockerfile
@@ -19,7 +19,8 @@ RUN curl "http://vergil.chemistry.gatech.edu/psicode-download/${PSI4_VERSION}.sh
 ENV PATH="/root/psi4conda/bin:${PATH}"
 ENV PYTHONPATH="/root/psi4conda/lib/python3.7/site-packages:/usr/local/lib/python3.7/dist-packages:${PYTHONPATH}"
 
-RUN python3 -m pip install scipy==1.2.2 \
+RUN python3 -m pip install --upgrade pip==20.2.4 && \ 
+    python3 -m pip install scipy==1.2.2 \
     numpy==1.15.4 \
     openfermion==0.10.0 \
     pyyaml==5.1 \


### PR DESCRIPTION
i think the issue was that psi4 installs a conda environment with its own python3, so installing python3 beforehand leads to duplicate binaries. we want to make sure python3 points to the one in the psi4conda venv. i removed the python3 install and the other stuff i don't think we need. it's building, and i can run 

python3
```python
>>> import psi4
>>> print(psi4)
<module 'psi4' from '/root/psi4conda/lib/python3.7/site-packages/psi4/__init__.py'>
```

without issue. So I think it's ready to try pushing to docker hub